### PR TITLE
[bug] files have to be added after pyinstaller

### DIFF
--- a/bundle_pyinstaller.sh
+++ b/bundle_pyinstaller.sh
@@ -283,7 +283,7 @@ clone_repos
 install_requirements
 install_sumo $sumo_path
 tweak_zope
-add_files
 run_pyinstaller
+add_files
 tweak_linux
 archive_bundle


### PR DESCRIPTION
otherwise the build folder is destroyed after the missing files have
been added.
